### PR TITLE
Add history command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 Make sure you have pnpm installed globally. If not, run the following command:
 
-`npm install -g pnpm`
+```
+npm install -g pnpm
+```
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,37 @@
 
 ![screenshot of slack](./example.png)
 
+## Prerequisite
+
+`npm install -g pnpm`
+
+## Create database
+
+```shell
+# create a new database for testing
+pnpm prisma:test db push
+
+# create a new database for a dev environment
+pnpm prisma db push
+```
+
 ## Running
 
-> TODO: Update README
+1. Create an .env file
+
+```shell
+cp .env.example .env
+```
+
+2. Search for `Handover Bot Test Env(ZilchWorld)` on `1Password`. Copy the credentials from `1Password` and paste them into the `.env` file
+
+3. Create a new account for `zilchworld.slack.com` or request an access on the #dev-handover channel
+
+4. Run the handover bot locally
+
+```shell
+pnpm run dev
+```
 
 ## Run Tests
 

--- a/README.md
+++ b/README.md
@@ -6,40 +6,42 @@
 
 ## Prerequisite
 
+Make sure you have pnpm installed globally. If not, run the following command:
+
 `npm install -g pnpm`
-
-## Create database
-
-```shell
-# create a new database for testing
-pnpm prisma:test db push
-
-# create a new database for a dev environment
-pnpm prisma db push
-```
 
 ## Running
 
 1. Create an .env file
 
 ```shell
-cp .env.example .env
+cp .env.template .env
 ```
 
-2. Search for `Handover Bot Test Env(ZilchWorld)` on `1Password`. Copy the credentials from `1Password` and paste them into the `.env` file
+2. Get the required credentials from `1Password` for `Handover Bot Test Env(ZilchWorld)`, and paste them into the `.env` file. Replace the placeholder for `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `HANDOVER_CHANNEL`, and `HANDOVER_TITLE`
 
-3. Create a new account for `zilchworld.slack.com` or request an access on the #dev-handover channel
+3. In the `.env` file, change `runn_handover_test` to `runn_handover`
 
-4. Run the handover bot locally
+4. create a new database for the dev environment
+
+```shell
+pnpm prisma db push
+```
+
+5. There's a Slack workspace for testing called `Zilchworld`. Create a new account on `zilchworld.slack.com` or request access on the #dev-handover channel
+
+6. Run the handover bot locally
 
 ```shell
 pnpm run dev
 ```
 
+7. Now you'll be able to run and test the handover bot on ZilchWorld!
+
 ## Run Tests
 
 ```shell
-cp .env.example .env.test
+cp .env.template .env.test
 
 # update DATABASE_URL to point to Postgre
 edit .env.test
@@ -48,8 +50,12 @@ edit .env.test
 pnpm install
 
 # run database migrations
-pnpm run prisma:test push db
+pnpm prisma:test db push
 
 # run tests!
 pnpm run test
 ```
+
+## Troubleshooting
+
+For any questions or discussions, please flick a message on #dev-handover

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -1,56 +1,112 @@
 import { randomUUID } from 'node:crypto'
-import { test, expect } from 'vitest'
+import { test, expect, beforeEach, describe } from 'vitest'
 import { assertOk } from '@stayradiated/error-boundary'
 import * as db from './db.js'
 
-test('getReminder: should support query batching', async () => {
+describe('db', () => {
   const userId = randomUUID()
   const date = '2022-08-15T00:00:00+00:00'
 
-  assertOk(
-    await db.upsertUser({ id: userId, name: 'Test User', timeZone: 'UTC' }),
-  )
+  beforeEach(async () => {
+    assertOk(
+      await db.upsertUser({ id: userId, name: 'Test User', timeZone: 'UTC' }),
+    )
+  })
 
-  const reminder = await db.upsertReminder({ userId, date, text: 'text' })
-  assertOk(reminder)
+  test('getReminder: should support query batching', async () => {
+    const reminder = await db.upsertReminder({ userId, date, text: 'text' })
+    assertOk(reminder)
 
-  const reminderList = await Promise.all([
-    db.getReminder({ userId, date }),
-    db.getReminder({ userId, date }),
-  ])
-  assertOk(reminderList[0])
-  assertOk(reminderList[1])
+    const reminderList = await Promise.all([
+      db.getReminder({ userId, date }),
+      db.getReminder({ userId, date }),
+    ])
+    assertOk(reminderList[0])
+    assertOk(reminderList[1])
 
-  expect(reminderList[0]?.id).toEqual(reminder.id)
-  expect(reminderList[1]?.id).toEqual(reminder.id)
-})
+    expect(reminderList[0]?.id).toEqual(reminder.id)
+    expect(reminderList[1]?.id).toEqual(reminder.id)
+  })
 
-test('getPostWithItems: should support query batching', async () => {
-  const userId = randomUUID()
-  const date = '2022-08-15T00:00:00+00:00'
+  test('getPostWithItems: should support query batching', async () => {
+    const post = await db.upsertPost({ userId, title: 'Title', date })
+    assertOk(post)
 
-  assertOk(
-    await db.upsertUser({ id: userId, name: 'Test User', timeZone: 'UTC' }),
-  )
-  const post = await db.upsertPost({ userId, title: 'Title', date })
-  assertOk(post)
+    assertOk(
+      await db.addPostItem({
+        postId: post.id,
+        text: 'text',
+        channel: 'channel',
+        ts: Date.now().toString(),
+      }),
+    )
 
-  assertOk(
-    await db.addPostItem({
-      postId: post.id,
-      text: 'text',
-      channel: 'channel',
-      ts: Date.now().toString(),
-    }),
-  )
+    const postList = await Promise.all([
+      db.getPostWithItems({ userId, date }),
+      db.getPostWithItems({ userId, date }),
+    ])
+    assertOk(postList[0])
+    assertOk(postList[1])
 
-  const postList = await Promise.all([
-    db.getPostWithItems({ userId, date }),
-    db.getPostWithItems({ userId, date }),
-  ])
-  assertOk(postList[0])
-  assertOk(postList[1])
+    expect(postList[0]?.id).toEqual(post.id)
+    expect(postList[1]?.id).toEqual(post.id)
+  })
 
-  expect(postList[0]?.id).toEqual(post.id)
-  expect(postList[1]?.id).toEqual(post.id)
+  test('getPostWithItemsForPeriod: should fetch posts for a period', async () => {
+    // arrange
+    const startDateOne = Date.now() - 1 * 24 * 60 * 60 * 1000
+    const startDateTwo = Date.now() - 2 * 24 * 60 * 60 * 1000
+
+    const postOne = await db.upsertPost({
+      userId,
+      title: 'Title',
+      date: new Date(startDateOne),
+    })
+    assertOk(postOne)
+    const postTwo = await db.upsertPost({
+      userId,
+      title: 'Title',
+      date: new Date(startDateTwo),
+    })
+    assertOk(postTwo)
+
+    // act
+    const postList = await db.getPostsWithItemsForPeriod({
+      userId,
+      daysBefore: 3,
+    })
+    assertOk(postList)
+
+    // assert
+    expect(postList.length).toEqual(2)
+  })
+
+  test('getPostWithItemsForPeriod: should not fetch posts outside of the period', async () => {
+    // arrange
+    const startDateOne = Date.now() - 1 * 24 * 60 * 60 * 1000
+    const startDateTwo = Date.now() - 2 * 24 * 60 * 60 * 1000
+
+    const postOne = await db.upsertPost({
+      userId,
+      title: 'Title',
+      date: new Date(startDateOne),
+    })
+    assertOk(postOne)
+    const postTwo = await db.upsertPost({
+      userId,
+      title: 'Title',
+      date: new Date(startDateTwo),
+    })
+    assertOk(postTwo)
+
+    // act
+    const postList = await db.getPostsWithItemsForPeriod({
+      userId,
+      daysBefore: 1,
+    })
+    assertOk(postList)
+
+    // assert
+    expect(postList.length).toEqual(1)
+  })
 })

--- a/src/db.ts
+++ b/src/db.ts
@@ -223,6 +223,36 @@ type PostWithItems = Extract<
   Post
 >
 
+type GetPostsWithItemsForPeriod = {
+  userId: string
+  daysBefore: number
+}
+
+const getPostsWithItemsForPeriod = async (
+  options: GetPostsWithItemsForPeriod,
+) => {
+  const { userId, daysBefore } = options
+  const startDate = Date.now() - daysBefore * 24 * 60 * 60 * 1000
+
+  return errorBoundary(() =>
+    prisma.post.findMany({
+      where: {
+        userId,
+        date: {
+          gte: new Date(startDate),
+        },
+      },
+      include: {
+        items: {
+          orderBy: {
+            ts: 'asc',
+          },
+        },
+      },
+    }),
+  )
+}
+
 const upsertFormat = async (format: Prisma.FormatUncheckedCreateInput) => {
   return errorBoundary(() =>
     prisma.format.upsert({
@@ -324,6 +354,7 @@ export {
   deletePostItem,
   getPostById,
   getPostWithItems,
+  getPostsWithItemsForPeriod,
   upsertFormat,
   updateFormatDeletedAt,
   getFormatList,


### PR DESCRIPTION
## Description

I thought it might be helpful to have a functionality to view a history of handover posts, similar to a report, covering a week or so

## Implementation

- Updated Readme
- Created a new command to fetch the history of handover posts for the user

## Testing 

Try to get a list of handover posts by typing
`@handoverbot history -p [date]`