### PR TITLE
fix: do not eat new lines

### DIFF
--- a/src/parse-date-from-message.test.ts
+++ b/src/parse-date-from-message.test.ts
@@ -77,4 +77,16 @@ describe('GetDateFromTsOptions', () => {
       message: '_(3 days late):_ (4 days ago): (5 days ago): hello',
     })
   })
+  test('allow new lines', () => {
+    const dateString = parseDateFromMessage({
+      messageText: '(3 days ago):  \nhello world',
+      ts,
+      timeZone: 'Pacific/Auckland',
+    })
+    expect(dateString).toEqual({
+      type: 'MATCH',
+      date: '2023-07-15T00:00:00+00:00',
+      message: '_(3 days late):_ \nhello world',
+    })
+  })
 })

--- a/src/parse-date-from-message.ts
+++ b/src/parse-date-from-message.ts
@@ -25,7 +25,9 @@ const parseDateFromMessage = (
   const instant = Number.parseInt(ts, 10) * 1000
 
   // Match if text starts with "(date):"
-  const regexMatch = /^\((today|yesterday|(\d+) days? ago)\):/.exec(messageText)
+  const regexMatch = /^\((today|yesterday|(\d+) days? ago)\): */.exec(
+    messageText,
+  )
   const relativeDate = regexMatch?.[1]
   const daysAgoString = regexMatch?.[2]
   if (!regexMatch || !relativeDate) {
@@ -64,9 +66,7 @@ Supported dates:
     timeZone,
   })
 
-  const messageWithoutRelativeDate = messageText
-    .slice(regexMatch[0].length)
-    .trim()
+  const messageWithoutRelativeDate = messageText.slice(regexMatch[0].length)
 
   const daysLater = dateFns.differenceInDays(instant, date)
 


### PR DESCRIPTION
Fixes a bug where you can't just have the date on a new line